### PR TITLE
Skip Failed Calibration Point and Continue Calibration

### DIFF
--- a/source/CustomCalibrationLibrary/Converters/NotBoolVisibilityConverter.cs
+++ b/source/CustomCalibrationLibrary/Converters/NotBoolVisibilityConverter.cs
@@ -12,7 +12,7 @@ namespace CustomCalibrationLibrary.Converters
     /// <summary>
     /// Converts True to Hidden and False to Visible
     /// </summary>
-    public class HasDataToVisibilityConverter: IValueConverter
+    public class NotBoolVisibilityConverter: IValueConverter
     {
         /// <summary>
         /// Value converter.
@@ -29,7 +29,7 @@ namespace CustomCalibrationLibrary.Converters
             if (targetType != typeof(Visibility))
                 throw new InvalidOperationException("The target must be of type visibility");
 
-            return (bool)value ? Visibility.Hidden : Visibility.Visible;
+            return (bool)value ? Visibility.Collapsed : Visibility.Visible;
         }
 
         /// <summary>

--- a/source/CustomCalibrationLibrary/Models/CalibrationModel.cs
+++ b/source/CustomCalibrationLibrary/Models/CalibrationModel.cs
@@ -9,6 +9,7 @@ using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.ComponentModel;
+using System.Linq;
 using System.Runtime.CompilerServices;
 using System.Windows;
 using System.Windows.Input;
@@ -325,6 +326,14 @@ namespace CustomCalibrationLibrary.Models
         }
 
         /// <summary>
+        /// Annotate calibration point as failed point.
+        /// </summary>
+        public void GazeDataCollectionFailed()
+        {
+            CalibrationPoints[Index].HasFailed = true;
+        }
+
+        /// <summary>
         /// Updates the calibration results on the screen.
         /// </summary>
         /// <param name="points"></param>
@@ -348,9 +357,11 @@ namespace CustomCalibrationLibrary.Models
                 }
                 double xAvg = (points[i].XCoordLeft + points[i].XCoordRight) / 2;
                 double yAvg = (points[i].YCoordLeft + points[i].YCoordRight) / 2;
-                CalibrationPoints[i].GazePositionAverage = new Point(xAvg, yAvg);
-                CalibrationPoints[i].GazePositionLeft = new Point(points[i].XCoordLeft, points[i].YCoordLeft);
-                CalibrationPoints[i].GazePositionRight = new Point(points[i].XCoordRight, points[i].YCoordRight);
+                CalibrationPoint point = CalibrationPoints.Where(p =>
+                        Math.Abs(p.Position.X - points[i].XCoord) < 0.00001 && Math.Abs(p.Position.Y - points[i].YCoord) < 0.00001).First();
+                point.GazePositionAverage = new Point(xAvg, yAvg);
+                point.GazePositionLeft = new Point(points[i].XCoordLeft, points[i].YCoordLeft);
+                point.GazePositionRight = new Point(points[i].XCoordRight, points[i].YCoordRight);
                 _logger.Debug($"Calibration at [{points[i].XCoord}, {points[i].YCoord}]: [{points[i].XCoordLeft}, {points[i].YCoordLeft}], [{xAvg}, {yAvg}], [{points[i].XCoordRight}, {points[i].YCoordRight}]");
             }
 

--- a/source/CustomCalibrationLibrary/Templates/CalibrationPoint.xaml
+++ b/source/CustomCalibrationLibrary/Templates/CalibrationPoint.xaml
@@ -11,12 +11,4 @@
             <Line X1="10" Y1="0" X2="10" Y2="20" Stroke="White" />
         </Grid>
     </ControlTemplate>
-    <ControlTemplate x:Key="FixationPoint">
-        <Grid
-            Height="20"
-            Width="20">
-            <Line X1="0" Y1="10" X2="20" Y2="10" Stroke="White" />
-            <Line X1="10" Y1="0" X2="10" Y2="20" Stroke="White" />
-        </Grid>
-    </ControlTemplate>
 </ResourceDictionary>

--- a/source/CustomCalibrationLibrary/ViewModels/CalibrationPointViewModel.cs
+++ b/source/CustomCalibrationLibrary/ViewModels/CalibrationPointViewModel.cs
@@ -29,6 +29,8 @@ namespace CustomCalibrationLibrary.ViewModels
             GazePositionAverage = point.GazePositionAverage;
             GazePositionLeft = point.GazePositionLeft;
             GazePositionRight = point.GazePositionRight;
+            HasData = point.HasData;
+            HasFailed = point.HasFailed;
         }
 
     }

--- a/source/CustomCalibrationLibrary/Views/CalibrationPoint.xaml
+++ b/source/CustomCalibrationLibrary/Views/CalibrationPoint.xaml
@@ -12,7 +12,7 @@
              d:DesignHeight="450" d:DesignWidth="800">
     <UserControl.Resources>
         <converter:PositionConverter x:Key="PositionConverter" />
-        <converter:HasDataToVisibilityConverter x:Key="HasDataToVisibilityConverter" />
+        <converter:NotBoolVisibilityConverter x:Key="HasDataToVisibilityConverter" />
         <Style x:Key="CalibrationPoint" TargetType="{x:Type Ellipse}">
             <Setter Property="Width" Value="20" />
             <Setter Property="Height" Value="20" />

--- a/source/CustomCalibrationLibrary/Views/CalibrationResultPoint.xaml
+++ b/source/CustomCalibrationLibrary/Views/CalibrationResultPoint.xaml
@@ -12,6 +12,7 @@
     <UserControl.Resources>
         <ResourceDictionary>
             <converter:PositionConverter x:Key="PositionConverter" />
+            <converter:NotBoolVisibilityConverter x:Key="HasFailedToVisibilityConverter" />
             <ResourceDictionary.MergedDictionaries>
                 <ResourceDictionary Source="pack://application:,,,/CustomCalibrationLibrary;component/Templates/CalibrationPoint.xaml" />
                 <ResourceDictionary Source="pack://application:,,,/CustomCalibrationLibrary;component/Styles/GazePoints.xaml" />
@@ -27,7 +28,7 @@
                 />
             </ContentControl.RenderTransform>
         </ContentControl>
-        <Grid>
+        <Grid Visibility="{Binding HasFailed, Converter={StaticResource HasFailedToVisibilityConverter}}">
             <Ellipse
                 Style="{StaticResource AverageGazePoint}"
             />
@@ -38,7 +39,7 @@
                 />
             </Grid.RenderTransform>
         </Grid>
-        <Grid>
+        <Grid Visibility="{Binding HasFailed, Converter={StaticResource HasFailedToVisibilityConverter}}">
             <Ellipse
                 Style="{StaticResource LeftGazePoint}"
             />
@@ -49,7 +50,7 @@
                 />
             </Grid.RenderTransform>
         </Grid>
-        <Grid>
+        <Grid Visibility="{Binding HasFailed, Converter={StaticResource HasFailedToVisibilityConverter}}">
             <Ellipse
                 Style="{StaticResource RightGazePoint}"
             />

--- a/source/GazeToMouse/App.xaml.cs
+++ b/source/GazeToMouse/App.xaml.cs
@@ -625,7 +625,9 @@ namespace GazeToMouse
                 if (!res)
                 {
                     HandleCalibrationError($"Failed to collect data for calibration point at [{point.X}, {point.Y}]");
-                    break;
+                    // Wait a little.
+                    await Task.Delay(700);
+                    continue;
                 }
 
                 _logger.Debug($"Calibration data collected at point [{point.X}, {point.Y}]");

--- a/source/GazeToMouse/App.xaml.cs
+++ b/source/GazeToMouse/App.xaml.cs
@@ -626,6 +626,7 @@ namespace GazeToMouse
 
                 if (!res)
                 {
+                    _calibrationModel.GazeDataCollectionFailed();
                     HandleCalibrationError($"Failed to collect data for calibration point at [{point.X}, {point.Y}]");
                     // Wait a little.
                     await Task.Delay(700);
@@ -842,9 +843,9 @@ namespace GazeToMouse
                     goto case CalibrationEventType.Start;
                 case CalibrationEventType.Start:
                     _calibrationModel.Error = "No Error";
+                    await Calibrate();
                     try
                     {
-                        await Calibrate();
                     }
                     catch (Exception ex)
                     {

--- a/source/GazeUtilityLibrary/DataStructs/CalibrationPoint.cs
+++ b/source/GazeUtilityLibrary/DataStructs/CalibrationPoint.cs
@@ -35,6 +35,16 @@ namespace GazeUtilityLibrary.DataStructs
             set { _hasData = value; OnPropertyChanged(); }
         }
 
+        private bool _hasFailed;
+        /// <summary>
+        /// Flag to indicate whether data has been collected for this calibration point.
+        /// </summary>
+        public bool HasFailed
+        {
+            get { return _hasFailed; }
+            set { _hasFailed = value; OnPropertyChanged(); }
+        }
+
         private Point _position;
         /// <summary>
         /// The position of the calibration point.
@@ -92,6 +102,7 @@ namespace GazeUtilityLibrary.DataStructs
         public CalibrationPoint(Point position, int index)
         {
             HasData = false;
+            HasFailed = false;
             Position = position;
             _index = index;
         }


### PR DESCRIPTION
Instead of stopping the calibration when failing to collect data for one point, skip the point and try to continue.

- [x] don't display data for failed calibration point